### PR TITLE
修改swoole最低支持版本号

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ then use command line to start it:
 
 `php server.php`
 
-To use `HproseSwooleServer`, you need install [swoole](http://www.swoole.com/) first. The minimum version of [swoole](https://github.com/swoole/swoole-src) been supported is 1.7.15.
+To use `HproseSwooleServer`, you need install [swoole](http://www.swoole.com/) first. The minimum version of [swoole](https://github.com/swoole/swoole-src) been supported is 1.7.16.
 
 `HproseSwooleServer` not only support creating http server，but also support create tcp, unix and websocket server. For examples:
 


### PR DESCRIPTION
项目中使用了swoole_client->set方法，而该方法是在swoole1.7.16中提供的，在低一点的版本中会提示报错：
```shell
PHP Fatal error:  Call to undefined method swoole_client::set()
```
在1.7.5的代码中并没有这个方法：https://github.com/swoole/swoole-src/blob/swoole-1.7.15-stable/swoole_client.c，
在1.7.16的版本（第39行）才有：https://github.com/swoole/swoole-src/blob/swoole-1.7.16-stable/swoole_client.c