### PR TITLE
test: fix phpunit 6 compatibility issue

### DIFF
--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,8 +1,9 @@
 <?php
 $loader = include __DIR__ . '/../vendor/autoload.php';
 
-use PHPUnit\Framework\TestCase;
+$psr4TestCaseClass = 'PHPUnit\Framework\TestCase';
+$psr0TestCaseClass = 'PHPUnit_Framework_TestCase';
 
-if (!class_exists(PHPUnit_Framework_TestCase::class) && class_exists(TestCase::class)) {
-    class_alias(TestCase::class, PHPUnit_Framework_TestCase::class);
+if (!class_exists($psr0TestCaseClass) && class_exists($psr4TestCaseClass)) {
+    class_alias($psr4TestCaseClass, $psr0TestCaseClass);
 }

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,2 +1,8 @@
 <?php
 $loader = include __DIR__ . '/../vendor/autoload.php';
+
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists(PHPUnit_Framework_TestCase::class) && class_exists(TestCase::class)) {
+    class_alias(TestCase::class, PHPUnit_Framework_TestCase::class);
+}

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -6,7 +6,7 @@
     </testsuites>
     <filter>
         <whitelist>
-            <directory>..</directory>
+            <directory>../src</directory>
             <exclude>
                 <directory>../vendor/</directory>
             </exclude>


### PR DESCRIPTION
close #41

I also limited the phpunit whitelist to directory /src, which is used to collect code coverage, use phpunit --coverage-* options.

```bash
phpunit5 --coverage-html ../temp/coverage
```

![image](https://cloud.githubusercontent.com/assets/3423411/26293948/eeb4deea-3ef2-11e7-894b-b4e8afdb914e.png)
