### PR TITLE
refactor: use composer autoload in favor of manual spl_autoload_register

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,11 @@
         "phpunit/phpunit": ">=4.0.0"
     },
     "autoload": {
-        "files": ["src/Hprose.php"]
+        "files": [
+            "src/init.php"
+        ],
+        "psr-4": {
+            "Hprose\\": "src/Hprose"
+        }
     }
 }

--- a/src/Hprose.php
+++ b/src/Hprose.php
@@ -14,105 +14,21 @@
  *                                                        *
  * hprose for php 5.3+                                    *
  *                                                        *
- * LastModified: Jul 30, 2016                             *
+ * LastModified: Jul 10, 2017                             *
  * Author: Ma Bingyao <andot@hprose.com>                  *
  *                                                        *
 \**********************************************************/
 
-require_once 'Throwable.php';
-require_once 'TypeError.php';
-require_once 'Hprose/Future/functions.php';
-require_once 'Hprose/Promise/functions.php';
-require_once 'Hprose/functions.php';
-require_once 'functions.php';
+require_once __DIR__ . '/init.php';
 
-spl_autoload_register(function($className) {
-    if ((strlen($className) > 6) && (strtolower(substr($className, 0, 6)) === "hprose")) {
-        if ($className{6} === '\\') {
-            include __DIR__ . DIRECTORY_SEPARATOR . str_replace("\\", DIRECTORY_SEPARATOR, $className) . ".php";
+// Autoload for non-composer applications
+spl_autoload_register(function ($className) {
+    if ((strlen($className) > 7) && (strtolower(substr($className, 0, 7)) === "hprose\\")) {
+        $file = __DIR__ . DIRECTORY_SEPARATOR . str_replace("\\", DIRECTORY_SEPARATOR, $className) . ".php";
+        if (is_file($file)) {
+            include $file;
+            return true;
         }
-        else {
-            // Deprecated
-            // Compatible with older versions only
-            // You'd better not use these classes.
-            switch (strtolower($className)) {
-                case 'hproseasync':
-                    class_alias('Hprose\\Async', 'HproseAsync');
-                    break;
-                case 'hprosecompleter':
-                    class_alias('Hprose\\Completer', 'HproseCompleter');
-                    break;
-                case 'hprosefuture':
-                    class_alias('Hprose\\Future', 'HproseFuture');
-                    break;
-                case 'hprosetags':
-                    class_alias('Hprose\\Tags', 'HproseTags');
-                    break;
-                case 'hprosebytesio':
-                    class_alias('Hprose\\BytesIO', 'HproseBytesIO');
-                    break;
-                case 'hproseclassmanager':
-                    class_alias('Hprose\\ClassManager', 'HproseClassManager');
-                    break;
-                case 'hproserawreader':
-                    class_alias('Hprose\\RawReader', 'HproseRawReader');
-                    break;
-                case 'hprosereader':
-                    class_alias('Hprose\\Reader', 'HproseReader');
-                    break;
-                case 'hprosewriter':
-                    class_alias('Hprose\\Writer', 'HproseWriter');
-                    break;
-                case 'hproseformatter':
-                    class_alias('Hprose\\Formatter', 'HproseFormatter');
-                    break;
-                case 'hproseresultmode':
-                    class_alias('Hprose\\ResultMode', 'HproseResultMode');
-                    break;
-                case 'hprosefilter':
-                    class_alias('Hprose\\Filter', 'HproseFilter');
-                    break;
-                case 'hproseclient':
-                    class_alias('Hprose\\Client', 'HproseClient');
-                    break;
-                case 'hproseservice':
-                    class_alias('Hprose\\Service', 'HproseService');
-                    break;
-                case 'hprosehttpclient':
-                    class_alias('Hprose\\Http\\Client', 'HproseHttpClient');
-                    break;
-                case 'hprosehttpservice':
-                    class_alias('Hprose\\Http\\Service', 'HproseHttpService');
-                    break;
-                case 'hprosehttpserver':
-                    class_alias('Hprose\\Http\\Server', 'HproseHttpServer');
-                    break;
-                case 'hprosesocketclient':
-                    class_alias('Hprose\\Socket\\Client', 'HproseSocketClient');
-                    break;
-                case 'hprosesocketservice':
-                    class_alias('Hprose\\Socket\\Service', 'HproseSocketService');
-                    break;
-                case 'hprosesocketserver':
-                    class_alias('Hprose\\Socket\\Server', 'HproseSocketServer');
-                    break;
-                case 'hprosejsonrpcclientfilter':
-                    class_alias('Hprose\\Filter\\JSONRPC\\ClientFilter', 'HproseJSONRPCClientFilter');
-                    break;
-                case 'hprosejsonrpcservicefilter':
-                    class_alias('Hprose\\Filter\\JSONRPC\\ServiceFilter', 'HproseJSONRPCServiceFilter');
-                    break;
-                case 'hprosexmlrpcclientfilter':
-                    class_alias('Hprose\\Filter\\XMLRPC\\ClientFilter', 'HproseXMLRPCClientFilter');
-                    break;
-                case 'hprosexmlrpcservicefilter':
-                    class_alias('Hprose\\Filter\\XMLRPC\\ServiceFilter', 'HproseXMLRPCServiceFilter');
-                    break;
-                default:
-                    return false;
-            }
-        }
-        return true;
     }
     return false;
 });

--- a/src/init.php
+++ b/src/init.php
@@ -1,0 +1,47 @@
+<?php
+
+require_once __DIR__ . '/Throwable.php';
+require_once __DIR__ . '/TypeError.php';
+require_once __DIR__ . '/Hprose/Future/functions.php';
+require_once __DIR__ . '/Hprose/Promise/functions.php';
+require_once __DIR__ . '/Hprose/functions.php';
+require_once __DIR__ . '/functions.php';
+
+// Deprecated
+// Compatible with older versions only
+// You'd better not use these classes.
+spl_autoload_register(function ($className) {
+    $oldVersionAliases = array(
+//        'hproseasync' => array('Hprose\\Async', 'HproseAsync'), // Hprose\Async not found
+        'hprosecompleter' => array('Hprose\\Completer', 'HproseCompleter'),
+        'hprosefuture' => array('Hprose\\Future', 'HproseFuture'),
+        'hprosetags' => array('Hprose\\Tags', 'HproseTags'),
+        'hprosebytesio' => array('Hprose\\BytesIO', 'HproseBytesIO'),
+        'hproseclassmanager' => array('Hprose\\ClassManager', 'HproseClassManager'),
+        'hproserawreader' => array('Hprose\\RawReader', 'HproseRawReader'),
+        'hprosereader' => array('Hprose\\Reader', 'HproseReader'),
+        'hprosewriter' => array('Hprose\\Writer', 'HproseWriter'),
+        'hproseformatter' => array('Hprose\\Formatter', 'HproseFormatter'),
+        'hproseresultmode' => array('Hprose\\ResultMode', 'HproseResultMode'),
+        'hprosefilter' => array('Hprose\\Filter', 'HproseFilter'),
+        'hproseclient' => array('Hprose\\Client', 'HproseClient'),
+        'hproseservice' => array('Hprose\\Service', 'HproseService'),
+        'hprosehttpclient' => array('Hprose\\Http\\Client', 'HproseHttpClient'),
+        'hprosehttpservice' => array('Hprose\\Http\\Service', 'HproseHttpService'),
+        'hprosehttpserver' => array('Hprose\\Http\\Server', 'HproseHttpServer'),
+        'hprosesocketclient' => array('Hprose\\Socket\\Client', 'HproseSocketClient'),
+        'hprosesocketservice' => array('Hprose\\Socket\\Service', 'HproseSocketService'),
+        'hprosesocketserver' => array('Hprose\\Socket\\Server', 'HproseSocketServer'),
+        'hprosejsonrpcclientfilter' => array('Hprose\\Filter\\JSONRPC\\ClientFilter', 'HproseJSONRPCClientFilter'),
+        'hprosejsonrpcservicefilter' => array('Hprose\\Filter\\JSONRPC\\ServiceFilter', 'HproseJSONRPCServiceFilter'),
+        'hprosexmlrpcclientfilter' => array('Hprose\\Filter\\XMLRPC\\ClientFilter', 'HproseXMLRPCClientFilter'),
+        'hprosexmlrpcservicefilter' => array('Hprose\\Filter\\XMLRPC\\ServiceFilter', 'HproseXMLRPCServiceFilter'),
+    );
+
+    if (isset($oldVersionAliases[$key = strtolower($className)])) {
+        list($original, $alias) = $oldVersionAliases[$key];
+        class_alias($original, $alias);
+        return true;
+    }
+    return false;
+});


### PR DESCRIPTION
Why make this change:
1. Composer autoloader is faster (class_map)
2. The original autoloader is not rigorous (missing is_file check)

Hprose.php is still available for non-composer users