### PR TITLE
当return 为字符串时 ,先检查class 是否存在  不自动载入

### DIFF
--- a/src/Hprose/Future.php
+++ b/src/Hprose/Future.php
@@ -97,7 +97,7 @@ class Future {
             $value->fill($this);
             return;
         }
-        if (($value !== NULL) and is_object($value) or is_string($value)) {
+        if (($value !== NULL) and is_object($value) or (is_string($value) and class_exists($value,false))) {
             if (method_exists($value, 'then')) {
                 $then = array($value, 'then');
                 $notrun = true;


### PR DESCRIPTION
or is_string($value) 改成了        or (is_string($value) and class_exists($value,false))

