### PR TITLE
Fix issue #73 double calls of clearTimeout()

### DIFF
--- a/src/Hprose/Service.php
+++ b/src/Hprose/Service.php
@@ -1044,8 +1044,9 @@ abstract class Service extends HandlerManager {
             $timer = $this->timer->setTimeout(function() use ($future) {
                 $future->reject(new TimeoutException('timeout'));
             }, $timeout);
-            $request->whenComplete(function() use ($self, $timer) {
-                $self->timer->clearTimeout($timer);
+            $request->whenComplete(function() use ($self, $topic, $id) {
+                $topics = $self->getTopics($topic);
+                $self->delTimer($topics, $id);
             })->fill($future);
             return $future->catchError(function($e) use ($self, $topics, $topic, $id) {
                 if ($e instanceof TimeoutException) {


### PR DESCRIPTION
Callback in `$request->whenComplete()` calls naked `clearTimeout()` without checking if the timer has been cleared already.

This may lead up to issue #73, and the swoole exception would interfere with subsequent promise fulfillment.

Using `delTimer()` instead of `clearTimeout()` would mitigate this issue.