### PR TITLE
Fix wrong time unit in Service->delay()

### DIFF
--- a/src/Hprose/Service.php
+++ b/src/Hprose/Service.php
@@ -471,9 +471,9 @@ abstract class Service extends HandlerManager {
         $stream->close();
         return $data;
     }
-    protected function delay($interval, $data) {
-        $seconds = floor($interval);
-        $nanoseconds = ($interval - $seconds) * 1000000000;
+    protected function delay($milliseconds, $data) {
+        $seconds = floor($milliseconds / 1000);
+        $nanoseconds = ($milliseconds % 1000) * 1000000;
         time_nanosleep($seconds, $nanoseconds);
         return Future\value($data);
     }


### PR DESCRIPTION
The delay() method misinterpreted its parameter as number in second while the value passed in are usually in millisecond.

This bug contributes to TCP `CLOSE_WAIT` issues on the server side when request is corrupted or exception occurs.