### PR TITLE
fix behavior of "@" operator for default errorHandler()

### DIFF
--- a/src/Hprose/Service.php
+++ b/src/Hprose/Service.php
@@ -101,7 +101,9 @@ abstract class Service extends HandlerManager {
 
     public function errorHandler($errno, $errstr, $errfile, $errline) {
         if (self::$trackError) {
-            self::$lastError = new ErrorException($errstr, 0, $errno, $errfile, $errline);
+            if(error_reporting()!==0){
+                self::$lastError = new ErrorException($errstr, 0, $errno, $errfile, $errline);
+            }
         } else if (self::$_lastErrorHandler){
             call_user_func(self::$_lastErrorHandler, $errno, $errstr, $errfile, $errline);
         }


### PR DESCRIPTION
According to the description of http://php.net/manual/en/language.operators.errorcontrol.php, in custom error handlers, we should check whether error_reporting() equals to 0, so that "@" operator can take effect in these cases. 

虽然rpc调用本身受这个问题影响不大，但是我的项目业务逻辑里面有很多地方用到@操作符，并且很难改写，如果不能主动抑制报错会很麻烦，应该有其他人也会有同样的困扰，希望小马哥可以把这个修复整合进来:-)