### PR TITLE
完善fwrite、fread返回值判断，修复特殊情况下死循环问题

### DIFF
--- a/src/Hprose/Socket/Transporter.php
+++ b/src/Hprose/Socket/Transporter.php
@@ -378,10 +378,14 @@ abstract class Transporter {
             }
         }
         if ($this->write($stream, $buffer) === false) {
+            @fclose($this->stream);
+            $this->stream = null;
             throw $this->getLastError("request write error");
         }
         $response = $this->read($stream, $buffer);
         if ($response === false) {
+            @fclose($this->stream);
+            $this->stream = null;
             throw $this->getLastError("response read error");
         }
         return $response;

--- a/src/Hprose/Socket/Transporter.php
+++ b/src/Hprose/Socket/Transporter.php
@@ -68,7 +68,7 @@ abstract class Transporter {
         $header = '';
         do {
             $buffer = fread($stream, $n - strlen($header));
-            if ($buffer === false) {
+            if ($buffer === false || '' === $buffer) {
                 return false;
             }
             $header .= $buffer;
@@ -128,7 +128,7 @@ abstract class Transporter {
         }
         $remaining = $response->length - strlen($response->buffer);
         $buffer = fread($stream, $remaining);
-        if (empty($buffer)) {
+        if (false === $buffer || '' === $buffer) {
             $this->asyncReadError($o, $stream, $response->index);
             return;
         }
@@ -294,7 +294,7 @@ abstract class Transporter {
         $retry = 3;
         while ($retry > 0) {
             $sent = fwrite($stream, $buffer, $length);
-            if ($sent === false) {
+            if ($sent === false || 0 === $sent) {
                 return false;
             }
             if ($sent == 0) {
@@ -318,7 +318,7 @@ abstract class Transporter {
         $response = '';
         while (($remaining = $length - strlen($response)) > 0) {
             $buffer = fread($stream, $remaining);
-            if ($buffer === false) {
+            if ($buffer === false || '' === $buffer) {
                 return false;
             }
             $response .= $buffer;


### PR DESCRIPTION
在通信时，如果服务器关闭或重启，会导致`fwrite`、`fread`时无限死循环。

`fwrite` 返回值为0，代表发送数据长度为0，可以认定为失败。

`fread` 返回值为空字符串，代表是超时，没有获取到任何数据，可以认定为失败。
