### PR TITLE
fix map or list judge error

### DIFF
--- a/src/Hprose/Writer.php
+++ b/src/Hprose/Writer.php
@@ -48,9 +48,7 @@ class Writer {
     }
     private static function isList(array $a) {
         $count = count($a);
-        return ($count === 0) ||
-               ((isset($a[0]) || array_key_exists(0, $a)) && (($count === 1) ||
-               (isset($a[$count - 1]) || array_key_exists($count - 1, $a))));
+        return ($count * ($count - 1) / 2) === array_sum(array_keys($a));
     }
     public function serialize($val) {
         if ($val === null) {


### PR DESCRIPTION
解决了判断list还是map的错误，之前有跳跃式数字key的数组会被判断成list，这次修改后就不会出现判断错误的情况了。