### PR TITLE
stream_set_timeout和stream_select中的usec单位是微秒

### DIFF
--- a/src/Hprose/Socket/Transporter.php
+++ b/src/Hprose/Socket/Transporter.php
@@ -261,7 +261,7 @@ abstract class Transporter {
                 $except = null;
                 $timeout = max(0, min($o->deadlines) - microtime(true));
                 $tv_sec = floor($timeout);
-                $tv_usec = ($timeout - $tv_sec) * 1000;
+                $tv_usec = ($timeout - $tv_sec) * 1000000;
                 $n = stream_select($read, $write, $except, $tv_sec, $tv_usec);
                 if ($n === false) {
                     $e = $this->getLastError('unkown io error.');
@@ -302,7 +302,7 @@ abstract class Transporter {
                 return false;
             }
             if ($sent == 0) {
-                time_nanosleep(0, 1000);
+                time_nanosleep(0, 1000000);
                 $retry--;
             }
             else if ($sent < $length) {


### PR DESCRIPTION
stream_set_timeout和stream_select中的usec单位是微秒（microsecond），而此处可能误以为是毫秒(millisecond)所以仅乘以了1000。当client的timeout小于1000ms时，会出现立即超时或response read error的问题